### PR TITLE
Fix ResponseStreamWrapper.Write to wait on async call

### DIFF
--- a/Westwind.AspnetCore.LiveReload/ResponseStreamWrapper.cs
+++ b/Westwind.AspnetCore.LiveReload/ResponseStreamWrapper.cs
@@ -44,7 +44,9 @@ namespace Westwind.AspnetCore.LiveReload
         {
             if (IsHtmlResponse())
             {
-                WebsocketScriptInjectionHelper.InjectLiveReloadScriptAsync(buffer, offset, count, _context, _baseStream);
+                WebsocketScriptInjectionHelper.InjectLiveReloadScriptAsync(buffer, offset, count, _context, _baseStream)
+                                              .GetAwaiter()
+                                              .GetResult();
             }
             else
                 _baseStream.Write(buffer, offset, count);


### PR DESCRIPTION
`ResponseStreamWrapper.Write`, which internally calls the async method `InjectLiveReloadScriptAsync`, never waits for it to complete and so could lead to corruption of sorts. This PR fixes that by blocking until the asynchronous operation completes.

I seriously doubted if ASP.NET Core ever calls the synchronous methods a `Stream` so this bug may never show up but I noticed the issue on passing and thought why take the risk of having it wrong?
