### PR TITLE
Fix syntax error in settings JSON sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ And you can use these configuration settings:
     "ClientFileExtensions": ".cshtml,.css,.js,.htm,.html,.ts,.razor,.custom",
     "ServerRefreshTimeout": 3000,
     "WebSocketUrl": "/__livereload",
-    "WebSocketHost": "ws://localhost:5000"
+    "WebSocketHost": "ws://localhost:5000",
     "FolderToMonitor": "~/"
   }
 }


### PR DESCRIPTION
A trailing comma (`,`) was missing.