### PR TITLE
Make sure we refresh only when the server is available

### DIFF
--- a/Westwind.AspnetCore.LiveReload/LiveReloadFileWatcher.cs
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadFileWatcher.cs
@@ -7,7 +7,7 @@ namespace Westwind.AspNetCore.LiveReload
 
         private static System.IO.FileSystemWatcher Watcher;
 
-        
+
         public static void StartFileWatcher()
         {
             var path = LiveReloadConfiguration.Current.FolderToMonitor;
@@ -21,7 +21,7 @@ namespace Westwind.AspNetCore.LiveReload
             Watcher.NotifyFilter = NotifyFilters.LastWrite
                                    | NotifyFilters.FileName
                                    | NotifyFilters.DirectoryName;
-                               
+
 
 
             Watcher.Changed += Watcher_Changed;
@@ -50,9 +50,9 @@ namespace Westwind.AspNetCore.LiveReload
 
             if (LiveReloadConfiguration.Current.ClientFileExtensions.Contains(ext))
             {
-                var task  = LiveReloadMiddleware.RefreshWebSocketRequest();
+                LiveReloadMiddleware.RefreshWebSocketRequest().Wait();
             }
-            
+
         }
 
         private static void Watcher_Renamed(object sender, RenamedEventArgs e)

--- a/Westwind.AspnetCore.LiveReload/LiveReloadMiddleware.cs
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadMiddleware.cs
@@ -132,13 +132,13 @@ namespace Westwind.AspNetCore.LiveReload
                 }
             }
 
-            
+
             ActiveSockets.Remove(webSocket);
             if (webSocket.State != WebSocketState.Closed &&
                 webSocket.State != WebSocketState.Aborted)
                 await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Socket closed",
                                            CancellationToken.None);
-            
+
         }
 
         /// <summary>

--- a/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
+++ b/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
@@ -154,7 +154,16 @@ function retryConnection() {{
    retry = setInterval(function() {{ 
                 console.log('Live Reload retrying connection.'); 
                 connection = tryConnect();  
-                if(connection) location.reload(true);                    
+                if(connection)
+                {{
+                    if(connection.readyState === 1){{
+                        location.reload(true);
+                    }} else {{
+                        connection.onopen = function(event) {{
+                            location.reload(true);
+                        }}
+                    }}
+                }}                 
             }},{config.ServerRefreshTimeout});
 }}
 

--- a/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
+++ b/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
@@ -115,56 +115,70 @@ namespace Westwind.AspnetCore.LiveReload
 (function() {{
 
 var retry = 0;
-var connection = tryConnect();
+var connection = tryConnect(true);
 
-function tryConnect(){{
+function tryConnect(retryOnFail){{
     try{{
         var host = '{hostString}';
         connection = new WebSocket(host); 
     }}
-    catch(ex) {{ console.log(ex); retryConnection(); }}
+    catch(ex) {{ 
+        console.log(ex);  
+        if(retryOnFail)
+            retryConnection();
+    }}
 
     if (!connection)
        return null;
 
-    clearInterval(retry);
+    
 
     connection.onmessage = function(message) 
     {{ 
         if (message.data == 'DelayRefresh') {{
-                    alert('Live Reload Delayed Reload.');
-            setTimeout( function() {{ location.reload(true); }},{config.ServerRefreshTimeout});
-                }}
+            alert('Live Reload Delayed Reload.');
+            setTimeout( 
+                function() {{ 
+                    location.reload(true); 
+                }},{config.ServerRefreshTimeout});
+        }}
         if (message.data == 'Refresh') 
           location.reload(true); 
     }}    
     connection.onerror = function(event)  {{
         console.log('Live Reload Socket error.', event);
-        retryConnection();
+        if(retryOnFail)
+            retryConnection();
     }}
     connection.onclose = function(event) {{
         console.log('Live Reload Socket closed.');
-        retryConnection();
+        if(retryOnFail)
+            retryConnection();
     }}
-
-    console.log('Live Reload socket connected.');
+    connection.onopen = function(event) {{
+        console.log('Live Reload socket connected.');
+    }}
     return connection;  
 }}
 function retryConnection() {{   
-   retry = setInterval(function() {{ 
-                console.log('Live Reload retrying connection.'); 
-                connection = tryConnect();  
-                if(connection)
-                {{
-                    if(connection.readyState === 1){{
-                        location.reload(true);
-                    }} else {{
-                        connection.onopen = function(event) {{
-                            location.reload(true);
-                        }}
-                    }}
-                }}                 
-            }},{config.ServerRefreshTimeout});
+   // we'll try every x ms to reconnect to the server
+   // once the server answer, we refresh the page as the build process is done
+   // we don't need to cancel the timeout as it'll be cancelled by the page refresh
+   setInterval(function() {{ 
+        console.log('Live Reload retrying connection.'); 
+        connection = tryConnect(false);  //we won't try to  reconnect onerror or onclose because it's handled by the settimeout
+        if(connection)
+        {{
+            if(connection.readyState === 1){{
+                location.reload(true);
+            }} else {{
+                connection.onopen = function(event) {{
+                    console.log('Live Reload socket connected.');
+                    location.reload(true);
+                }}
+            }}
+        }}                 
+    }},{config.ServerRefreshTimeout});
 }}
 
 }})();


### PR DESCRIPTION
Hi,

While testing this project I saw that most of the time the refresh occurs when the server is not available . This gives a connection closed error on the browser (chrome is nice and tries to detect when the server is available, but sometimes it fails). 

This change detect when the server connection is really available and refresh only when it's ok. I think this makes the ServerRefreshTimeout useless as it'll refresh when the build is over (we can change it with a const value like 500).

I know this is an uncalled PR, sorry if it doesn't provide any value.