### PR TITLE
Change Middleware to rely on Options system

### DIFF
--- a/Westwind.AspnetCore.LiveReload/AutoConfigureLiveReloadConfiguration.cs
+++ b/Westwind.AspnetCore.LiveReload/AutoConfigureLiveReloadConfiguration.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Westwind.AspNetCore.LiveReload;
+
+namespace Westwind.AspnetCore.LiveReload
+{
+    /// <summary>
+    /// The MS Options system will call this to automatically initialize the configuration from the configuration file.
+    /// This is one of the "magic" pieces of glue that allows pulling from DI and configuring nicely during the AddXX
+    /// function call.
+    /// </summary>
+    internal class AutoConfigureLiveReloadConfiguration : IConfigureOptions<LiveReloadConfiguration>
+    {
+        private readonly IConfiguration _configuration;
+
+        public AutoConfigureLiveReloadConfiguration(
+            IConfiguration configuration
+        )
+        {
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// This gets called during the standard configuration process in order to automatically wire up the configuration settings
+        /// to the <c>LiveReload</c> configuration section.
+        /// </summary>
+        /// <param name="options">The options instance to configure.</param>
+        public void Configure(LiveReloadConfiguration options)
+        {
+            _configuration.Bind("LiveReload", options);
+        }
+    }
+}

--- a/Westwind.AspnetCore.LiveReload/LiveReloadConfiguration.cs
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadConfiguration.cs
@@ -9,12 +9,6 @@ namespace Westwind.AspNetCore.LiveReload
     public class LiveReloadConfiguration
     {
         /// <summary>
-        /// Current configuration instance accessible through out the middleware
-        /// </summary>
-        public static LiveReloadConfiguration Current { get; set; }
-
-
-        /// <summary>
         /// Determines whether live reload is enabled. If off, there's no
         /// overhead in this middleware and it simply passes through requests.
         /// </summary>

--- a/Westwind.AspnetCore.LiveReload/LiveReloadMiddleware.cs
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadMiddleware.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Westwind.AspnetCore.LiveReload;
 
 namespace Westwind.AspNetCore.LiveReload
@@ -18,12 +19,14 @@ namespace Westwind.AspNetCore.LiveReload
     public class LiveReloadMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly IOptionsMonitor<LiveReloadConfiguration> _configuration;
         internal static HashSet<WebSocket> ActiveSockets = new HashSet<WebSocket>();
 
 
-        public LiveReloadMiddleware(RequestDelegate next)
+        public LiveReloadMiddleware(RequestDelegate next, IOptionsMonitor<LiveReloadConfiguration> configuration)
         {
             _next = next;
+            _configuration = configuration;
         }
 
 
@@ -36,7 +39,7 @@ namespace Westwind.AspNetCore.LiveReload
 
         public async Task InvokeAsync(HttpContext context)
         {
-            var config = LiveReloadConfiguration.Current;
+            var config = _configuration.CurrentValue;
             if (!config.LiveReloadEnabled)
             {
                 await _next(context);
@@ -82,7 +85,7 @@ namespace Westwind.AspNetCore.LiveReload
         /// <returns></returns>
         private async Task<bool> HandleWebSocketRequest(HttpContext context)
         {
-            var config = LiveReloadConfiguration.Current;
+            var config = _configuration.CurrentValue;
 
             // Handle WebSocket Connection
             if (context.Request.Path == config.WebSocketUrl)

--- a/Westwind.AspnetCore.LiveReload/PostConfigureLiveReloadConfiguration.cs
+++ b/Westwind.AspnetCore.LiveReload/PostConfigureLiveReloadConfiguration.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using Westwind.AspNetCore.LiveReload;
+
+namespace Westwind.AspnetCore.LiveReload
+{
+    /// <summary>
+    /// The MS Options system will call this in order to initialize a bunch of the settings that need access
+    /// to other objects that are registered in DI.
+    ///
+    /// This is a *POST* Configure so it happens after all the other user configuration in order to clean up
+    /// for users and handle any options that they may have left at the default.
+    /// </summary>
+    /// <seealso cref="Microsoft.Extensions.Options.IPostConfigureOptions{Westwind.AspNetCore.LiveReload.LiveReloadConfiguration}" />
+    internal class PostConfigureLiveReloadConfiguration : IPostConfigureOptions<LiveReloadConfiguration>
+    {
+#if NETCORE2
+        private readonly IHostingEnvironment _environment;
+#else
+        private readonly IWebHostEnvironment _environment;
+#endif
+
+        public PostConfigureLiveReloadConfiguration(
+#if NETCORE2
+            IHostingEnvironment environment
+#else
+            IWebHostEnvironment environment
+#endif
+        )
+        {
+            _environment = environment;
+        }
+
+        public void PostConfigure(string name, LiveReloadConfiguration options)
+        {
+            if (string.IsNullOrEmpty(options.FolderToMonitor))
+            {
+                options.FolderToMonitor = _environment.ContentRootPath;
+            }
+
+            else if (options.FolderToMonitor.StartsWith("~"))
+            {
+                if (options.FolderToMonitor.Length > 1)
+                {
+                    var folder = options.FolderToMonitor.Substring(1);
+                    if (folder.StartsWith('/') || folder.StartsWith("\\"))
+                        folder = folder.Substring(1);
+                    options.FolderToMonitor = Path.Combine(_environment.ContentRootPath, folder);
+                    options.FolderToMonitor = Path.GetFullPath(options.FolderToMonitor);
+                }
+                else
+                {
+                    options.FolderToMonitor = _environment.ContentRootPath;
+                }
+            }
+        }
+    }
+}

--- a/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
+++ b/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Westwind.AspNetCore.LiveReload;
 
 namespace Westwind.AspnetCore.LiveReload
@@ -97,7 +99,7 @@ namespace Westwind.AspnetCore.LiveReload
 
         public static string GetWebSocketClientJavaScript(HttpContext context)
         {
-            var config = LiveReloadConfiguration.Current;
+            var config = context.RequestServices.GetRequiredService<IOptionsMonitor<LiveReloadConfiguration>>().CurrentValue;
 
             var host = context.Request.Host;
             string hostString;


### PR DESCRIPTION
As discussed on Twitter, this changes the AddXX function to be able to configure everything without having to build the IServiceProvider by using the MS Options system and DI.