### PR TITLE
Handle loss of file watcher functionality when folder being watched is recreated (after deletion).

### DIFF
--- a/Westwind.AspnetCore.LiveReload/LiveReloadFileWatcher.cs
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadFileWatcher.cs
@@ -8,35 +8,73 @@ namespace Westwind.AspNetCore.LiveReload
     public class LiveReloadFileWatcher
     {
 
-        private static System.IO.FileSystemWatcher Watcher;
-
+        private static System.IO.FileSystemWatcher FileWatcher;
+        private static System.IO.FileSystemWatcher FolderWatcher;
+        private static string FolderToMonitorPath;
+        private static string FolderToMonitorName;
+        private static bool _isFolderCreated = false;
+        private static ThrottlingTimer _throttler = new ThrottlingTimer();
 
         public static void StartFileWatcher()
         {
             if (!LiveReloadConfiguration.Current.LiveReloadEnabled)
                 return;
-            
-           var path = LiveReloadConfiguration.Current.FolderToMonitor;
-            path = Path.GetFullPath(path);
 
-            Watcher = new FileSystemWatcher(path);
-            Watcher.Filter = "*.*";
-            Watcher.EnableRaisingEvents = true;
-            Watcher.IncludeSubdirectories = true;
-
-            Watcher.NotifyFilter = NotifyFilters.LastWrite
-                                   | NotifyFilters.FileName
-                                   | NotifyFilters.DirectoryName;
-
-            Watcher.Changed += Watcher_Changed;
-            Watcher.Created += Watcher_Changed;
-            Watcher.Renamed += Watcher_Renamed;
+            var path = LiveReloadConfiguration.Current.FolderToMonitor;
+            FolderToMonitorPath = Path.GetFullPath(path);
+            FolderToMonitorName = Path.GetFileName(FolderToMonitorPath);
+            StartFilesWatcher();
+            StartFolderWatcher();
         }
 
         public void StopFileWatcher()
         {
-            Watcher?.Dispose();
-            Watcher = null;
+            DisposeFilesWatcher();
+            DisposeFolderWatcher();
+            _throttler = null;
+        }
+
+        private static void StartFilesWatcher()
+        {
+            FileWatcher = new FileSystemWatcher(FolderToMonitorPath);
+            FileWatcher.Filter = "*.*";
+            FileWatcher.EnableRaisingEvents = true;
+            FileWatcher.IncludeSubdirectories = true;
+
+            FileWatcher.NotifyFilter = NotifyFilters.LastWrite
+                                   | NotifyFilters.FileName
+                                   | NotifyFilters.DirectoryName;
+
+            FileWatcher.Changed += FileWatcher_Changed;
+            FileWatcher.Created += FileWatcher_Changed;
+            FileWatcher.Renamed += FileWatcher_Renamed;
+        }
+
+        private static void StartFolderWatcher()
+        {
+            var parentPath = Path.GetDirectoryName(FolderToMonitorPath);
+            var folderName = Path.GetFileName(FolderToMonitorPath);
+            FolderWatcher = new FileSystemWatcher(parentPath);
+            FolderWatcher.Filter = folderName;
+            FolderWatcher.EnableRaisingEvents = true;
+            FolderWatcher.IncludeSubdirectories = false;
+
+
+            FolderWatcher.Created += FolderWatcher_Created;
+            FolderWatcher.Deleted += FolderWatcher_Deleted;
+            FolderWatcher.Renamed += FolderWatcher_Renamed;
+        }
+
+        private static void DisposeFilesWatcher()
+        {
+            FileWatcher?.Dispose();
+            FileWatcher = null;
+        }
+
+        private static void DisposeFolderWatcher()
+        {
+            FolderWatcher?.Dispose();
+            FolderWatcher = null;
         }
 
         private static List<string> _extensionList;
@@ -60,22 +98,56 @@ namespace Westwind.AspNetCore.LiveReload
 
             if (_extensionList.Contains(ext,StringComparer.OrdinalIgnoreCase))
             {
-                // delayed - no longer needed as server restarts automatically refresh on restart
-                //bool delayed = ext == ".cshtml" || ext == ".cs" || ext == ".json"  || ext == ".xml";
-                _ = LiveReloadMiddleware.RefreshWebSocketRequest(); // delayed
+                if (_isFolderCreated)
+                {
+
+                    _throttler.Debounce(2000, param =>
+                    {
+                        _ = LiveReloadMiddleware.RefreshWebSocketRequest();
+                        _isFolderCreated = false;
+                    });
+                }
+                else
+                {
+                    // delayed - no longer needed as server restarts automatically refresh on restart
+                    //bool delayed = ext == ".cshtml" || ext == ".cs" || ext == ".json"  || ext == ".xml";
+                    _ = LiveReloadMiddleware.RefreshWebSocketRequest(); // delayed
+                }
             }
 
         }
 
-        private static void Watcher_Renamed(object sender, RenamedEventArgs e)
+        private static void FileWatcher_Renamed(object sender, RenamedEventArgs e)
         {
             FileChanged(e.FullPath);
         }
 
-
-        private static void Watcher_Changed(object sender, System.IO.FileSystemEventArgs e)
+        private static void FileWatcher_Changed(object sender, System.IO.FileSystemEventArgs e)
         {
             FileChanged(e.FullPath);
+        }
+
+        private static void FolderWatcher_Created(object sender, FileSystemEventArgs e)
+        {
+            _isFolderCreated = true;
+            StartFilesWatcher();
+        }
+
+        private static void FolderWatcher_Deleted(object sender, System.IO.FileSystemEventArgs e)
+        {
+            DisposeFilesWatcher();
+        }
+
+        private static void FolderWatcher_Renamed(object sender, RenamedEventArgs e)
+        {
+            if (string.Compare(e.Name, FolderToMonitorName, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                StartFileWatcher();
+            }
+            else if (string.Compare(e.OldName, FolderToMonitorName, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                DisposeFilesWatcher();
+            }
         }
     }
 }

--- a/Westwind.AspnetCore.LiveReload/LiveReloadFileWatcher.cs
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadFileWatcher.cs
@@ -67,12 +67,20 @@ namespace Westwind.AspNetCore.LiveReload
 
         private static void DisposeFilesWatcher()
         {
+            FileWatcher.Changed -= FileWatcher_Changed;
+            FileWatcher.Created -= FileWatcher_Changed;
+            FileWatcher.Renamed -= FileWatcher_Renamed;
+            FileWatcher.EnableRaisingEvents = false;
             FileWatcher?.Dispose();
             FileWatcher = null;
         }
 
         private static void DisposeFolderWatcher()
         {
+            FolderWatcher.Created -= FolderWatcher_Created;
+            FolderWatcher.Deleted -= FolderWatcher_Deleted;
+            FolderWatcher.Renamed -= FolderWatcher_Renamed;
+            FolderWatcher.EnableRaisingEvents = false;
             FolderWatcher?.Dispose();
             FolderWatcher = null;
         }

--- a/Westwind.AspnetCore.LiveReload/ThrottlingTimer.cs
+++ b/Westwind.AspnetCore.LiveReload/ThrottlingTimer.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Timers;
+/// <summary>
+/// Inspired from : https://weblog.west-wind.com/posts/2017/jul/02/debouncing-and-throttling-dispatcher-events
+/// Provides Debounce() and Throttle() methods.
+/// Use these methods to ensure that events aren't handled too frequently.
+/// 
+/// Throttle() ensures that events are throttled by the interval specified.
+/// Only the last event in the interval sequence of events fires.
+/// 
+/// Debounce() fires an event only after the specified interval has passed
+/// in which no other pending event has fired. Only the last event in the
+/// sequence is fired.
+/// </summary>
+public class ThrottlingTimer
+{
+    private Lazy<Timer> safeTimer
+        = new Lazy<Timer>(System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+    private DateTime timerStarted { get; set; } = DateTime.UtcNow.AddYears(-1);
+
+    /// <summary>
+    /// Debounce an event by resetting the event timeout every time the event is 
+    /// fired. The behavior is that the Action passed is fired only after events
+    /// stop firing for the given timeout period.
+    /// 
+    /// Use Debounce when you want events to fire only after events stop firing
+    /// after the given interval timeout period.
+    /// 
+    /// Wrap the logic you would normally use in your event code into
+    /// the  Action you pass to this method to debounce the event.   
+    /// </summary>
+    /// <param name="interval">Timeout in Milliseconds</param>
+    /// <param name="action">Action<object> to fire when debounced event fires</object></param>
+    /// <param name="param">optional parameter</param>
+    public void Debounce(int interval, Action<object> action,
+        object param = null)
+    {
+        // kill pending timer and pending ticks
+        Timer timer = safeTimer.Value;        
+        timer?.Stop();
+
+        // timer is recreated for each event and effectively
+        // resets the timeout. Action only fires after timeout has fully
+        // elapsed without other events firing in between
+
+        timer.Elapsed += (s, e) =>
+        {
+            if (!timer.Enabled)
+                return;
+
+            timer?.Stop();
+            action.Invoke(param);
+        };
+        timer.Interval = interval;       
+        
+
+        timer.Start();
+    }
+
+    /// <summary>
+    /// This method throttles events by allowing only 1 event to fire for the given
+    /// timeout period. Only the last event fired is handled - all others are ignored.
+    /// Throttle will fire events every timeout ms even if additional events are pending.
+    /// 
+    /// Use Throttle where you need to ensure that events fire at given intervals.
+    /// </summary>
+    /// <param name="interval">Timeout in Milliseconds</param>
+    /// <param name="action">Action<object> to fire when debounced event fires</object></param>
+    /// <param name="param">optional parameter</param>
+    public void Throttle(int interval, Action<object> action,
+        object param = null)
+    {
+        // kill pending timer and pending ticks
+        Timer timer = safeTimer.Value;
+        timer?.Stop();
+
+        var curTime = DateTime.UtcNow;
+
+        // if timeout is not up yet - adjust timeout to fire 
+        // with potentially new Action parameters           
+        if (curTime.Subtract(timerStarted).TotalMilliseconds < interval)
+            interval -= (int)curTime.Subtract(timerStarted).TotalMilliseconds;
+
+        timer.Elapsed += (s, e) =>
+        {
+            if (!timer.Enabled)
+                return;
+
+            timer?.Stop();
+            action.Invoke(param);
+        };
+        timer.Interval = interval;
+
+        timer.Start();
+        timerStarted = curTime;
+    }
+}


### PR DESCRIPTION
Handle loss of file watcher functionality when folder being watched is recreated (after deletion).

Also, handle possible sudden burst of new changes on folder re-creation which otherwise leads to exceptionally high number of browser reload requests(within a very short period of few seconds) that makes browser unresponsive.
This is typically helpful when live reloading is set up  for standalone folder of SPA frameworks (like Angular / React/ Vue) but ASP.NET Core server continues to run without restarting, and we want to rebuild (stop and rebuild) the client side code (e.g. Angular / React) in watch mode (e.g. 'ng build --watch' in case of Angular). In such cases the SPA output folder (e.g. 'dist' in Angular or 'public' in React) are typically deleted and recreated as part of its clean build process. In such cases Live Reload fails as the FileWatcher stops watching (at least in Windows) when the folder it is supposed to watch has been deleted and recreated. The only way to start monitoring the newly recreated standalone folder is by restarting the ASP.NET Core service even though the change was in client.
Additionally, possible renaming (either programmatically or manually for any reason in any scenario) of  the folder to be monitored is also handled. For example if we delete a folder manually, the FileWatcher stops watching it (at least in Windows) and creating it again manually is considered renaming in Windows - hence handling renaming of the folder being monitored can make this middleware more robust and reliable.