### PR TITLE
Fix for large number of reloads

### DIFF
--- a/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
+++ b/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs
@@ -96,7 +96,7 @@ namespace Westwind.AspNetCore.LiveReload
         static int LastIndexOf<T>(this T[] array, T[] sought) where T : IEquatable<T> =>
             array.AsSpan().LastIndexOf(sought);
 
-        
+
 
 
         public static string GetWebSocketClientJavaScript(HttpContext context)
@@ -124,10 +124,10 @@ var connection = tryConnect(true);
 function tryConnect(retryOnFail){{
     try{{
         var host = '{hostString}';
-        connection = new WebSocket(host); 
+        connection = new WebSocket(host);
     }}
-    catch(ex) {{ 
-        console.log(ex);  
+    catch(ex) {{
+        console.log(ex);
         if(retryOnFail)
             retryConnection();
     }}
@@ -136,18 +136,18 @@ function tryConnect(retryOnFail){{
        return null;
 
 
-    connection.onmessage = function(message) 
-    {{ 
+    connection.onmessage = function(message)
+    {{
         if (message.data == 'DelayRefresh') {{
             console.log('Live Reload Delayed Reload.');
-            setTimeout( 
-                function() {{ 
-                    location.reload(); 
+            setTimeout(
+                function() {{
+                    location.reload();
                 }},{config.ServerRefreshTimeout});
         }}
-        if (message.data == 'Refresh')           
+        if (message.data == 'Refresh')
           setTimeout(function()  {{ location.reload(); }}, 10);
-    }}    
+    }}
     connection.onerror = function(event)  {{
         console.log('Live Reload Socket error.', event);
         if(retryOnFail)
@@ -163,21 +163,24 @@ function tryConnect(retryOnFail){{
     }}
     return connection;
 }}
-function retryConnection() {{   
-      setInterval(function() {{ 
-        console.log('Live Reload retrying connection.'); 
+function retryConnection() {{
+    var interval = setInterval(function() {{
+        console.log('Live Reload retrying connection.');
+        connection.onopen = null;
         connection = tryConnect(false);
         if(connection)
         {{
             if(connection.readyState === 1){{
                 location.reload(true);
+                clearInterval(interval);
             }} else {{
                 connection.onopen = function(event) {{
                     console.log('Live Reload socket connected.');
                     location.reload(true);
+                    clearInterval(interval);
                 }}
             }}
-        }}                 
+        }}
     }},{config.ServerRefreshTimeout});
 }}
 


### PR DESCRIPTION
In the current version of this package, setting the ServerRefreshTimeout value to a low value can result in many, many, reload attempts when the JS snippet reconnects to the server. To see this issue in action most egregiously, set the ServerRefreshTimeout to 0.

This PR has two changes that resolve this issue:

https://github.com/RickStrahl/Westwind.AspnetCore.LiveReload/blob/cfbb73aefc9f4e9d3701896bd46b82e577c20d4f/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs#L166-L170
First, I added `connection.onopen = null` to the retry logic. This will clear any existing onopen event handlers prior to the `connection` variable being overwritten (the existing connection object would continue to persist in the background after `tryConnect`), which would include a reload action if this is not the first time retrying. If those handlers are allowed to exist, they will **all** fire as soon as the pile of websockets reestablish connection, leading to many reloads.

https://github.com/RickStrahl/Westwind.AspnetCore.LiveReload/blob/cfbb73aefc9f4e9d3701896bd46b82e577c20d4f/Westwind.AspnetCore.LiveReload/WebsocketScriptInjectionHelper.cs#L166-L183
Second, as soon as a successful connection is established, I've added `clearInterval()` calls to prevent the retry logic from continuing to retry.
