### PR TITLE
Prevent closed socket connection from interrupting navigation

### DIFF
--- a/Samples/Westwind.AspnetCore.LiveReload.Web50/Pages/SlowPage.cshtml
+++ b/Samples/Westwind.AspnetCore.LiveReload.Web50/Pages/SlowPage.cshtml
@@ -1,0 +1,20 @@
+@page
+@using System.Threading
+
+@{
+    ViewData["Title"] = "Slow-loading page";
+    Thread.Sleep(1000);
+}
+<h1>@ViewData["Title"]</h1>
+<p>This page takes a second to load. This is to test that when navigating to this page, the socket connection doesn't close and prompt a reload on certain browsers.</p>
+
+<div class="mt-4">
+    <a href="~/home/index">Home Page</a>
+</div>
+
+
+<hr />
+
+<small>To demonstrate Live Reloading on this page edit <code>Pages/SlowPage.cshtml</code></small>
+<br />
+<small>You can also edit <code>wwwroot/css/site.css</code> to live reload style changes</small>

--- a/Samples/Westwind.AspnetCore.LiveReload.Web50/appsettings.json
+++ b/Samples/Westwind.AspnetCore.LiveReload.Web50/appsettings.json
@@ -9,6 +9,6 @@
   "AllowedHosts": "*",
   "LiveReload": {
     "LiveReloadEnabled": false,
-    "LiveReloadScriptUrl":  "/__livereloadscript";
+    "LiveReloadScriptUrl":  "/__livereloadscript"
   }
 }

--- a/Westwind.AspnetCore.LiveReload/LiveReloadClientScript.js
+++ b/Westwind.AspnetCore.LiveReload/LiveReloadClientScript.js
@@ -5,6 +5,21 @@
     }
 
     var retry = 0;
+    var isClosing = false;
+    window.addEventListener("beforeunload", function () {
+        // Prevent reload events triggered by closing the connection from interrupting navigation.
+        isClosing = true;
+        console.debug("Live Reload is paused due to beforeunload event.");
+        setTimeout(function () {
+            // Assume that the user clicked Stay on Page if this logic is executing after the timeout.
+            isClosing = false;
+            if (connection) {
+                connection.onopen = null;
+                connection = tryConnect(true);
+                console.debug("Live Reload has resumed after unload was cancelled.");
+            }
+        }, 2500);
+    });
     var connection = tryConnect(true);
 
     function tryConnect(retryOnFail) {
@@ -40,7 +55,7 @@
         }
         connection.onclose = function (event) {
             console.log('Live Reload Socket closed.');
-            if (retryOnFail)
+            if (retryOnFail && !isClosing)
                 retryConnection();
         }
         connection.onopen = function (event) {


### PR DESCRIPTION
In some browsers (namely, Firefox), the WebSocket onclose handler is invoked immediately when navigation has started. As a result, when the livereload script tries to reload the page, it ends up interrupting the browser navigation and ends up reloading the current page instead.

This is fixed by adding some logic to the livereload script that listens to the beforeunload event and pauses the logic for reloading once navigation has started. Also, in case the page has an onbeforeunload handler defined and navigation has been cancelled, the logic will set up the websocket connection again after a certain interval has passed.

Fixes #48