### PR TITLE
Integrate SourceLink

### DIFF
--- a/Westwind.AspnetCore.LiveReload/Westwind.AspNetCore.LiveReload.csproj
+++ b/Westwind.AspnetCore.LiveReload/Westwind.AspNetCore.LiveReload.csproj
@@ -29,13 +29,9 @@
 </PropertyGroup>
   
   <PropertyGroup>
-    <IncludeSymbols>true</IncludeSymbols>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageOutputPath>./nupkg</PackageOutputPath>    
-
     <PackageCopyright>Rick Strahl, West Wind Technologies 2019-2021</PackageCopyright>
     <PackageTags>Live Reload AspNetCore Middleware Westwind</PackageTags>
-    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/RickStrahl/Westwind.AspnetCore.LiveReload#change-log</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicense>LICENSE.MD</PackageLicense>
 
@@ -44,10 +40,10 @@
   </PropertyGroup>
 
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <DocumentationFile>./Westwind.AspNetCore.LiveReload.xml</DocumentationFile>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
 
@@ -70,5 +66,8 @@
     <None Include="LICENSE.MD" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
 
 </Project>

--- a/Westwind.AspnetCore.LiveReload/publish-nuget.ps1
+++ b/Westwind.AspnetCore.LiveReload/publish-nuget.ps1
@@ -1,9 +1,11 @@
 
-if (test-path ./nupkg) {
-    remove-item ./nupkg -Force -Recurse
-}   
+foreach ($path in "./nupkg", "./bin", "./obj") {
+    if (test-path $path) {
+        remove-item $path -Force -Recurse
+    }
+}
 
-dotnet build -c Release
+dotnet pack --configuration Release --output ./nupkg -p:ContinuousIntegrationBuild=true
 
 # $filename = 'LiveReloadServer.0.2.4.nupkg'
 $filename = gci "./nupkg/*.nupkg" | sort LastWriteTime | select -last 1 | select -ExpandProperty "Name"


### PR DESCRIPTION
When using the embedded debug type, the snupkg file is no longer needed.

The publish script was updated to build a NuGet package that passes all the NuGet Package Explorer validations.